### PR TITLE
fix IOS 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ TWEAK_NAME = adspeed
 $(TWEAK_NAME)_CFLAGS = -fobjc-arc
 $(TWEAK_NAME)_CCFLAGS = -std=c++11 -fno-rtti -fno-exceptions -DNDEBUG
 $(TWEAK_NAME)_FILES = Tweak.xm
+$(TWEAK_NAME)_FRAMEWORKS = UIKit QuartzCore CoreGraphics AVFoundation
 
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
Add FRAMEWORKS to fix tweak that isn't working in IOS 16, tested in 11 Promax 16.1